### PR TITLE
feat(i3): add ping results query

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,6 +10,7 @@ Documentation:
 Metrics/BlockLength:
   Exclude:
     - "bin/bundle"
+    - "spec/**/*_spec.rb"
 
 Metrics/CyclomaticComplexity:
   Exclude:
@@ -18,3 +19,6 @@ Metrics/CyclomaticComplexity:
 Metrics/MethodLength:
   Exclude:
     - "bin/bundle"
+
+Naming/VariableNumber:
+  EnforcedStyle: snake_case

--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ gem 'bootsnap', '>= 1.4.4', require: false
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: %i[mri mingw x64_mingw]
-  gem 'factory_bot'
+  gem 'factory_bot_rails'
   gem 'rspec-rails'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -71,6 +71,9 @@ GEM
     erubi (1.10.0)
     factory_bot (6.1.0)
       activesupport (>= 5.0.0)
+    factory_bot_rails (6.1.0)
+      factory_bot (~> 6.1.0)
+      railties (>= 5.0.0)
     ffi (1.14.2)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
@@ -191,7 +194,7 @@ PLATFORMS
 DEPENDENCIES
   bootsnap (>= 1.4.4)
   byebug
-  factory_bot
+  factory_bot_rails
   listen (~> 3.3)
   pg
   puma (~> 5.0)

--- a/app/queries/timeframe_ping_results_query.rb
+++ b/app/queries/timeframe_ping_results_query.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class TimeframePingResultsQuery
+  attr_reader :relation, :host, :port, :timeframe_starts_at, :timeframe_ends_at
+
+  def initialize(relation = PingResult.all, host:, port:, timeframe_starts_at:, timeframe_ends_at: Time.current)
+    @relation = relation
+    @host = host
+    @port = port
+    @timeframe_starts_at = timeframe_starts_at
+    @timeframe_ends_at = timeframe_ends_at
+  end
+
+  def query
+    relation
+      .where(host: host, port: port, created_at: timeframe_starts_at..timeframe_ends_at)
+  end
+end

--- a/spec/queries/timeframe_ping_results_query_spec.rb
+++ b/spec/queries/timeframe_ping_results_query_spec.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe TimeframePingResultsQuery do
+  let(:host) { '8.8.8.8' }
+  let(:port) { 80 }
+  let(:options) { {} }
+
+  describe '#initialize' do
+    subject { described_class.new(**options) }
+
+    it 'tells that not all arguments are proveded' do
+      expect { subject }.to raise_error ArgumentError
+    end
+
+    context 'with host and port specified' do
+      before do
+        options.merge!(host: host, port: port)
+      end
+
+      it 'tells that not all arguments are proveded' do
+        expect { subject }.to raise_error ArgumentError
+      end
+
+      context 'with timeframe_starts_at specified' do
+        before do
+          options.merge!(timeframe_starts_at: 1.hour.ago)
+        end
+
+        it 'correctly instanciates an object' do
+          expect { subject }.not_to raise_error
+        end
+      end
+    end
+  end
+
+  describe '#query' do
+    subject { described_class.new(**options).query }
+
+    context 'with ping results set in the database' do
+      let(:another_host) { '127.0.0.1' }
+      let(:another_port) { 3000 }
+
+      let!(:host_ping_result_1) do
+        create :ping_result, created_at: 13.hours.ago, host: host, port: port
+      end
+
+      let!(:host_ping_result_2) do
+        create :ping_result, created_at: 11.hours.ago, host: host, port: port
+      end
+
+      let!(:another_host_ping_result) do
+        create :ping_result, created_at: 8.hours.ago, host: another_host, port: port
+      end
+
+      let!(:another_port_ping_result) do
+        create :ping_result, created_at: 7.hours.ago, host: host, port: another_port
+      end
+
+      let!(:host_ping_result_3) do
+        create :ping_result, created_at: 6.hours.ago, host: host, port: port
+      end
+
+      let!(:host_ping_result_4) do
+        create :ping_result, created_at: 4.hours.ago, host: host, port: port
+      end
+
+      context 'with existing port/host/timeframe specified' do
+        before do
+          options.merge!({
+                           host: host,
+                           port: port,
+                           timeframe_starts_at: 12.hours.ago,
+                           timeframe_ends_at: 5.hours.ago
+                         })
+        end
+
+        it 'returns ping results for given host and port in a given timeframe' do
+          expect(subject).to match_array [host_ping_result_2, host_ping_result_3]
+        end
+      end
+
+      context 'with non-existing port/host/timeframe specified' do
+        before do
+          options.merge!({
+                           host: '0.0.0.0',
+                           port: port,
+                           timeframe_starts_at: 12.hours.ago,
+                           timeframe_ends_at: 5.hours.ago
+                         })
+        end
+
+        it 'returns nothing' do
+          expect(subject).to match_array []
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
- add ping results query to get ping results for a host in a timeframe
- tune rubocop a bit

https://github.com/daniilsunyaev/servers_ping_stats/issues/3