### PR TITLE
fix(i15): drop port requirements

### DIFF
--- a/app/controllers/ping_statistics_controller.rb
+++ b/app/controllers/ping_statistics_controller.rb
@@ -28,6 +28,6 @@ class PingStatisticsController < ActionController::API
   end
 
   def statistics_params
-    params.permit(:host, :port, :timeframe_starts_at, :timeframe_ends_at)
+    params.permit(:host, :timeframe_starts_at, :timeframe_ends_at)
   end
 end

--- a/app/models/host_monitoring.rb
+++ b/app/models/host_monitoring.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class HostMonitoring < ApplicationRecord
-  validates :host, :port, presence: true
+  validates :host, presence: true
 end

--- a/app/models/ping_result.rb
+++ b/app/models/ping_result.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class PingResult < ApplicationRecord
-  validates :host, :port, presence: true
+  validates :host, presence: true
 end

--- a/app/queries/timeframe_ping_results_query.rb
+++ b/app/queries/timeframe_ping_results_query.rb
@@ -1,18 +1,17 @@
 # frozen_string_literal: true
 
 class TimeframePingResultsQuery
-  attr_reader :relation, :host, :port, :timeframe_starts_at, :timeframe_ends_at
+  attr_reader :relation, :host, :timeframe_starts_at, :timeframe_ends_at
 
-  def initialize(relation = PingResult.all, host:, port: nil, timeframe_starts_at:, timeframe_ends_at: Time.current)
+  def initialize(relation = PingResult.all, host:, timeframe_starts_at:, timeframe_ends_at: Time.current)
     @relation = relation
     @host = host
-    @port = port
     @timeframe_starts_at = timeframe_starts_at
     @timeframe_ends_at = timeframe_ends_at
   end
 
   def query
     relation
-      .where(host: host, port: port, created_at: timeframe_starts_at..timeframe_ends_at)
+      .where(host: host, created_at: timeframe_starts_at..timeframe_ends_at)
   end
 end

--- a/app/queries/timeframe_ping_results_query.rb
+++ b/app/queries/timeframe_ping_results_query.rb
@@ -3,7 +3,7 @@
 class TimeframePingResultsQuery
   attr_reader :relation, :host, :port, :timeframe_starts_at, :timeframe_ends_at
 
-  def initialize(relation = PingResult.all, host:, port:, timeframe_starts_at:, timeframe_ends_at: Time.current)
+  def initialize(relation = PingResult.all, host:, port: nil, timeframe_starts_at:, timeframe_ends_at: Time.current)
     @relation = relation
     @host = host
     @port = port

--- a/app/value_objects/ping_statistics_request_params.rb
+++ b/app/value_objects/ping_statistics_request_params.rb
@@ -26,7 +26,6 @@ class PingStatisticsRequestParams
 
     {
       host: host,
-      port: port,
       timeframe_starts_at: timeframe_starts_at,
       timeframe_ends_at: timeframe_ends_at
     }
@@ -49,10 +48,6 @@ class PingStatisticsRequestParams
 
   def host
     action_controller_params[:host]
-  end
-
-  def port
-    action_controller_params[:port]
   end
 
   def timeframe_starts_at

--- a/app/value_objects/ping_statistics_request_params.rb
+++ b/app/value_objects/ping_statistics_request_params.rb
@@ -6,7 +6,7 @@ class PingStatisticsRequestParams
   BLANK_ERROR = "Can't be blank"
   TOO_LONG_TIMEFRAME_ERROR = 'Specified timeframe should less than 30 days'
 
-  REQUIRED_PARAMS = %i[host port timeframe_starts_at].freeze
+  REQUIRED_PARAMS = %i[host timeframe_starts_at].freeze
   MAX_TIMEFRAME = 30.days
 
   def initialize(action_controller_params)

--- a/db/migrate/20210210055510_drop_port_constraints.rb
+++ b/db/migrate/20210210055510_drop_port_constraints.rb
@@ -1,0 +1,6 @@
+class DropPortConstraints < ActiveRecord::Migration[6.1]
+  def change
+    change_column_null :host_monitorings, :port, from: false, to: true
+    change_column_null :ping_results, :port, from: false, to: true
+  end
+end

--- a/db/migrate/20210210062323_remove_port_columns.rb
+++ b/db/migrate/20210210062323_remove_port_columns.rb
@@ -1,0 +1,8 @@
+class RemovePortColumns < ActiveRecord::Migration[6.1]
+  def change
+    remove_column :host_monitorings, :port
+    remove_index :ping_results, name: 'index_ping_results_on_host_and_port'
+    remove_column :ping_results, :port
+    add_index :ping_results, :host
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,14 +10,13 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_10_055510) do
+ActiveRecord::Schema.define(version: 2021_02_10_062323) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "host_monitorings", force: :cascade do |t|
     t.string "host", null: false
-    t.integer "port"
     t.datetime "ended_at"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
@@ -26,14 +25,13 @@ ActiveRecord::Schema.define(version: 2021_02_10_055510) do
 
   create_table "ping_results", force: :cascade do |t|
     t.string "host", null: false
-    t.integer "port"
     t.float "duration"
     t.string "error"
     t.string "warning"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["created_at"], name: "index_ping_results_on_created_at", using: :brin
-    t.index ["host", "port"], name: "index_ping_results_on_host_and_port"
+    t.index ["host"], name: "index_ping_results_on_host"
   end
 
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,14 +10,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_09_134153) do
+ActiveRecord::Schema.define(version: 2021_02_10_055510) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "host_monitorings", force: :cascade do |t|
     t.string "host", null: false
-    t.integer "port", null: false
+    t.integer "port"
     t.datetime "ended_at"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
@@ -26,7 +26,7 @@ ActiveRecord::Schema.define(version: 2021_02_09_134153) do
 
   create_table "ping_results", force: :cascade do |t|
     t.string "host", null: false
-    t.integer "port", null: false
+    t.integer "port"
     t.float "duration"
     t.string "error"
     t.string "warning"

--- a/spec/controllers/ping_statistics_controller_spec.rb
+++ b/spec/controllers/ping_statistics_controller_spec.rb
@@ -20,9 +20,9 @@ describe PingStatisticsController, type: :controller do
       end
     end
 
-    context 'with host and port specified' do
+    context 'with host  specified' do
       let(:params) do
-        { host: '8.8.8.8', port: 80 }
+        { host: '8.8.8.8' }
       end
 
       it 'requires parameters to be set' do
@@ -57,7 +57,6 @@ describe PingStatisticsController, type: :controller do
           let!(:ping_result) do
             create :ping_result,
                    host: '8.8.8.8',
-                   port: 80,
                    duration: 0.5,
                    created_at: 45.minutes.ago
           end
@@ -65,15 +64,13 @@ describe PingStatisticsController, type: :controller do
           let!(:failed_ping_result) do
             create :ping_result,
                    host: '8.8.8.8',
-                   port: 80,
                    duration: nil,
                    created_at: 45.minutes.ago
           end
 
           let!(:another_ping_result) do
             create :ping_result,
-                   host: '8.8.8.8',
-                   port: 3000,
+                   host: '1.1.1.1',
                    duration: 0.05,
                    created_at: 45.minutes.ago
           end

--- a/spec/controllers/ping_statistics_controller_spec.rb
+++ b/spec/controllers/ping_statistics_controller_spec.rb
@@ -16,7 +16,7 @@ describe PingStatisticsController, type: :controller do
 
         json_body = JSON.parse(response.body)
 
-        expect(json_body['errors'].keys).to match_array(%w[host port timeframe_starts_at])
+        expect(json_body['errors'].keys).to match_array(%w[host timeframe_starts_at])
       end
     end
 

--- a/spec/factories/ping_results.rb
+++ b/spec/factories/ping_results.rb
@@ -3,6 +3,5 @@
 FactoryBot.define do
   factory :ping_result do
     host { '8.8.8.8' }
-    port { 80 }
   end
 end

--- a/spec/models/host_monitoring_spec.rb
+++ b/spec/models/host_monitoring_spec.rb
@@ -4,5 +4,4 @@ require 'rails_helper'
 
 describe HostMonitoring, type: :model do
   it { is_expected.to validate_presence_of(:host) }
-  it { is_expected.to validate_presence_of(:port) }
 end

--- a/spec/models/ping_result_spec.rb
+++ b/spec/models/ping_result_spec.rb
@@ -4,5 +4,4 @@ require 'rails_helper'
 
 describe PingResult, type: :model do
   it { is_expected.to validate_presence_of(:host) }
-  it { is_expected.to validate_presence_of(:port) }
 end

--- a/spec/queries/timeframe_ping_results_query_spec.rb
+++ b/spec/queries/timeframe_ping_results_query_spec.rb
@@ -39,30 +39,25 @@ describe TimeframePingResultsQuery do
 
     context 'with ping results set in the database' do
       let(:another_host) { '127.0.0.1' }
-      let(:another_port) { 3000 }
 
       let!(:host_ping_result_1) do
-        create :ping_result, created_at: 13.hours.ago, host: host, port: nil
+        create :ping_result, created_at: 13.hours.ago, host: host
       end
 
       let!(:host_ping_result_2) do
-        create :ping_result, created_at: 11.hours.ago, host: host, port: nil
+        create :ping_result, created_at: 11.hours.ago, host: host
       end
 
       let!(:another_host_ping_result) do
-        create :ping_result, created_at: 8.hours.ago, host: another_host, port: nil
-      end
-
-      let!(:another_port_ping_result) do
-        create :ping_result, created_at: 7.hours.ago, host: host, port: another_port
+        create :ping_result, created_at: 8.hours.ago, host: another_host
       end
 
       let!(:host_ping_result_3) do
-        create :ping_result, created_at: 6.hours.ago, host: host, port: nil
+        create :ping_result, created_at: 6.hours.ago, host: host
       end
 
       let!(:host_ping_result_4) do
-        create :ping_result, created_at: 4.hours.ago, host: host, port: nil
+        create :ping_result, created_at: 4.hours.ago, host: host
       end
 
       context 'with existing host/timeframe specified' do
@@ -74,12 +69,12 @@ describe TimeframePingResultsQuery do
                          })
         end
 
-        it 'returns ping results for given host and port in a given timeframe' do
+        it 'returns ping results for given host  in a given timeframe' do
           expect(subject).to match_array [host_ping_result_2, host_ping_result_3]
         end
       end
 
-      context 'with non-existing port/host/timeframe specified' do
+      context 'with non-existing host/timeframe specified' do
         before do
           options.merge!({
                            host: '0.0.0.0',

--- a/spec/queries/timeframe_ping_results_query_spec.rb
+++ b/spec/queries/timeframe_ping_results_query_spec.rb
@@ -4,7 +4,6 @@ require 'rails_helper'
 
 describe TimeframePingResultsQuery do
   let(:host) { '8.8.8.8' }
-  let(:port) { 80 }
   let(:options) { {} }
 
   describe '#initialize' do
@@ -14,9 +13,9 @@ describe TimeframePingResultsQuery do
       expect { subject }.to raise_error ArgumentError
     end
 
-    context 'with host and port specified' do
+    context 'with host specified' do
       before do
-        options.merge!(host: host, port: port)
+        options.merge!(host: host)
       end
 
       it 'tells that not all arguments are proveded' do
@@ -43,15 +42,15 @@ describe TimeframePingResultsQuery do
       let(:another_port) { 3000 }
 
       let!(:host_ping_result_1) do
-        create :ping_result, created_at: 13.hours.ago, host: host, port: port
+        create :ping_result, created_at: 13.hours.ago, host: host, port: nil
       end
 
       let!(:host_ping_result_2) do
-        create :ping_result, created_at: 11.hours.ago, host: host, port: port
+        create :ping_result, created_at: 11.hours.ago, host: host, port: nil
       end
 
       let!(:another_host_ping_result) do
-        create :ping_result, created_at: 8.hours.ago, host: another_host, port: port
+        create :ping_result, created_at: 8.hours.ago, host: another_host, port: nil
       end
 
       let!(:another_port_ping_result) do
@@ -59,18 +58,17 @@ describe TimeframePingResultsQuery do
       end
 
       let!(:host_ping_result_3) do
-        create :ping_result, created_at: 6.hours.ago, host: host, port: port
+        create :ping_result, created_at: 6.hours.ago, host: host, port: nil
       end
 
       let!(:host_ping_result_4) do
-        create :ping_result, created_at: 4.hours.ago, host: host, port: port
+        create :ping_result, created_at: 4.hours.ago, host: host, port: nil
       end
 
-      context 'with existing port/host/timeframe specified' do
+      context 'with existing host/timeframe specified' do
         before do
           options.merge!({
                            host: host,
-                           port: port,
                            timeframe_starts_at: 12.hours.ago,
                            timeframe_ends_at: 5.hours.ago
                          })
@@ -85,7 +83,6 @@ describe TimeframePingResultsQuery do
         before do
           options.merge!({
                            host: '0.0.0.0',
-                           port: port,
                            timeframe_starts_at: 12.hours.ago,
                            timeframe_ends_at: 5.hours.ago
                          })

--- a/spec/value_objects/ping_statistics_request_params_spec.rb
+++ b/spec/value_objects/ping_statistics_request_params_spec.rb
@@ -69,11 +69,11 @@ describe PingStatisticsRequestParams do
 
     context 'with valid parameters' do
       before do
-        params.merge!(host: '8.8.8.8', port: 80, timeframe_starts_at: '1612888444')
+        params.merge!(host: '8.8.8.8', timeframe_starts_at: '1612888444')
       end
 
       it 'sets parameters' do
-        expect(subject.slice(:host, :port)).to eq({ host: '8.8.8.8', port: 80 })
+        expect(subject.slice(:host, :port)).to eq({ host: '8.8.8.8', port: nil })
         expect(subject[:timeframe_starts_at].class).to eq DateTime
         expect(subject[:timeframe_ends_at].class).to eq DateTime
       end

--- a/spec/value_objects/ping_statistics_request_params_spec.rb
+++ b/spec/value_objects/ping_statistics_request_params_spec.rb
@@ -17,9 +17,9 @@ describe PingStatisticsRequestParams do
       expect(value_object.errors).not_to be_blank
     end
 
-    context 'when host and port are specified' do
+    context 'when host is specified' do
       before do
-        params.merge!(host: '0.0.0.0', port: 30)
+        params.merge!(host: '0.0.0.0')
       end
 
       it { is_expected.to eq false }
@@ -73,7 +73,7 @@ describe PingStatisticsRequestParams do
       end
 
       it 'sets parameters' do
-        expect(subject.slice(:host, :port)).to eq({ host: '8.8.8.8', port: nil })
+        expect(subject[:host]).to eq '8.8.8.8'
         expect(subject[:timeframe_starts_at].class).to eq DateTime
         expect(subject[:timeframe_ends_at].class).to eq DateTime
       end


### PR DESCRIPTION
icmp does not have a port option, so we can safely drop it

https://github.com/daniilsunyaev/servers_ping_stats/issues/15